### PR TITLE
Add support for annotating primary injectors with javax.inject.Inject

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -6,7 +6,7 @@ import mill.scalalib.publish._
 
 object core extends Module {
     val versions = new {
-        val release = "0.0.11"
+        val release = "0.0.12"
 
         val scala212 = "2.12.13"
         val scala213 = "2.13.5"

--- a/build.sc
+++ b/build.sc
@@ -36,7 +36,10 @@ object core extends Module {
         override def millSourcePath = super.millSourcePath / os.up
     }
     trait CommonTestModule extends ScalaModule with TestModule {
-        override def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.scalatest::scalatest::${versions.scalatest}")
+        override def ivyDeps = super.ivyDeps() ++ Agg(
+            ivy"org.scalatest::scalatest::${versions.scalatest}",
+            ivy"javax.inject:javax.inject:1",
+        )
         def testFrameworks = Seq("org.scalatest.tools.Framework")
     }
     object jvm extends Cross[JvmModule](versions.cross: _*)

--- a/core/src-2/jam/JamMacro.scala
+++ b/core/src-2/jam/JamMacro.scala
@@ -90,10 +90,11 @@ object JamMacro {
         val allConstructors = tpe.members
             .filter(m => m.isMethod && m.isPublic).map(_.asMethod)
             .filter(m => m.isConstructor && m.typeSignatureIn(tpe).finalResultType =:= tpe)
-        val hasPrimaryConstructorAnnotation = (m: c.universe.MethodSymbol) => m.annotations.exists(_.toString == "javax.inject.Inject")
-        val annotatedConstructors = allConstructors.filter(hasPrimaryConstructorAnnotation)
         if (allConstructors.isEmpty)
             c.abort(c.enclosingPosition, s"Unable to find public constructor for $prefix($tpe)")
+
+        val hasPrimaryConstructorAnnotation = (m: c.universe.MethodSymbol) => m.annotations.exists(_.toString == "javax.inject.Inject")
+        val annotatedConstructors = allConstructors.filter(hasPrimaryConstructorAnnotation)
         val constructors = if (annotatedConstructors.size >= 1) annotatedConstructors else allConstructors
         if (constructors.size > 1)
             c.abort(c.enclosingPosition, s"More than one primary constructor was found for $prefix($tpe)")

--- a/core/src-3/jam/JamMacro.scala
+++ b/core/src-3/jam/JamMacro.scala
@@ -100,13 +100,18 @@ object JamMacro {
     ): (q.reflect.Symbol, List[(Boolean, List[q.reflect.ValDef])]) = {
         import q.reflect.*
         val ttrArgs = getTtrArguments(ttr)
-        val constructors = ttr.tpe.typeSymbol.declarations
+        val allConstructors = ttr.tpe.typeSymbol.declarations
             .filter(m => m.isClassConstructor).map(_.tree)
             .collect { case m: DefDef if ttrArgs.fold(
                 m.returnTpt.tpe)(
                 args => m.returnTpt.tpe.asInstanceOf[AppliedType].tycon.appliedTo(args.values.toList)
             ) =:= ttr.tpe => m }
-        if (constructors.isEmpty) report.throwError(s"Unable to find public constructor for $prefix(${ttr.show})")
+
+        if (allConstructors.isEmpty) report.throwError(s"Unable to find public constructor for $prefix(${ttr.show})")
+
+        val hasPrimaryConstructorAnnotation = (ctor: q.reflect.DefDef) => ctor.symbol.annotations.map(_.tpe.show).contains("javax.inject.Inject")
+        val annotatedConstructors = allConstructors.filter(hasPrimaryConstructorAnnotation)
+        val constructors = if (annotatedConstructors.size >= 1) annotatedConstructors else allConstructors
         if (constructors.size > 1)
             report.throwError(s"More than one primary constructor was found for $prefix(${ttr.show})")
         constructors.head.symbol -> constructors.head.termParamss.map(tp => tp.isImplicit -> tp.params)

--- a/core/test/src/jam/JamSpec.scala
+++ b/core/test/src/jam/JamSpec.scala
@@ -1,5 +1,6 @@
 package jam
 
+import javax.inject.Inject
 import org.scalatest.freespec.AnyFreeSpec
 
 class JamSpec extends AnyFreeSpec {
@@ -28,6 +29,12 @@ class JamSpec extends AnyFreeSpec {
         }
         class WithGenericAndPlainArgs[A](val a: A, val b: WithSingleArg)
         class WithStringArg(val a: String)
+        class WithAnnotatedConstructor(val x: Int) {
+            @Inject()
+            def this(s: String) = this(s.length)
+
+            def this(d: Double) = this(d.toInt)
+        }
 
         "should brew" - {
 
@@ -73,6 +80,14 @@ class JamSpec extends AnyFreeSpec {
                     val a = "string"
                     val b = brew[WithStringArg]
                     assert(b.a.eq(a))
+                }
+            }
+
+            "objects for classes with an annotated primary constructor" in {
+                new {
+                    val s = "string"
+                    val result = brew[WithAnnotatedConstructor]
+                    assert(result.x == (s.length))
                 }
             }
 


### PR DESCRIPTION
This is a proof of concept PR to allow classes with multiple constructors to annotate one of their constructors with the `javax.inject.Inject` annotation, which will make that constructor preferred by Jam. While this isn't useful in the case where you control the code (since `brew` can also accept an arbitrary function argument), it's useful if you're working with generated code that makes these assumptions. The foremost example of that is the Play Framework, which generates Routes classes that have multiple constructors, with one annotated as the primary constructor.